### PR TITLE
Add disambiguation for SCons files

### DIFF
--- a/lib/rouge/guessers/disambiguation.rb
+++ b/lib/rouge/guessers/disambiguation.rb
@@ -101,6 +101,13 @@ module Rouge
 
         Cpp
       end
+
+      disambiguate '*.sc' do
+        next Python if matches?(/^#/)
+        next SuperCollider if matches?(/(?:^~|;$)/)
+
+        next Python
+      end
     end
   end
 end

--- a/lib/rouge/lexers/python.rb
+++ b/lib/rouge/lexers/python.rb
@@ -8,7 +8,7 @@ module Rouge
       desc "The Python programming language (python.org)"
       tag 'python'
       aliases 'py'
-      filenames '*.py', '*.pyw', 'SConstruct', 'SConscript', '*.tac'
+      filenames '*.py', '*.pyw', '*.sc', 'SConstruct', 'SConscript', '*.tac'
       mimetypes 'text/x-python', 'application/x-python'
 
       def self.detect?(text)

--- a/spec/lexers/python_spec.rb
+++ b/spec/lexers/python_spec.rb
@@ -10,6 +10,10 @@ describe Rouge::Lexers::Python do
     it 'guesses by filename' do
       assert_guess :filename => 'foo.py'
       assert_guess :filename => 'foo.pyw'
+      assert_guess :filename => '*.sc', :source => '# A comment'
+      assert_guess :filename => 'SConstruct'
+      assert_guess :filename => 'SConscript'
+      assert_guess :filename => 'foo.tac'
     end
 
     it 'guesses by mimetype' do

--- a/spec/lexers/supercollider_spec.rb
+++ b/spec/lexers/supercollider_spec.rb
@@ -9,7 +9,8 @@ describe Rouge::Lexers::SuperCollider do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.scd'
-      assert_guess :filename => 'foo.sc'
+      assert_guess :filename => 'foo.sc', :source => '~x = 3'
+      assert_guess :filename => 'foo.sc', :source => '0;'
     end
   end
 end


### PR DESCRIPTION
Here's the disambiguation code. It's not perfect since Python can use semicolons and `#` and `~` could begin lines if they're inside comment blocks but I think it's a decent enough heuristic. It can always be improved later. 

Once you accept this PR, your PR on the main repo should update automatically.

Let me know if anything is unclear!